### PR TITLE
[BUGFIX] Replace long gone f:form.textbox

### DIFF
--- a/Resources/Private/Backend/Templates/Blog/New.html
+++ b/Resources/Private/Backend/Templates/Blog/New.html
@@ -24,7 +24,7 @@
     <f:render partial="FormErrors" arguments="{for: 'newBlog'}" />
     <f:form method="post" controller="Blog" action="create" name="newBlog" object="{newBlog}">
         <label for="title">Title <span class="required">(required)</span></label><br />
-        <f:form.textbox property="title" />
+        <f:form.textfield property="title" />
         <br />
         <label for="description">Description (max. 150 chars)</label><br />
         <f:form.textarea property="description" rows="8" cols="46" />


### PR DESCRIPTION
Search results hint that f:form.textbox is gone since TYPO3 v4.7.  This
commit replaces it with f:form.textfield, as suggested in
 - https://docs.typo3.org/typo3cms/exceptions/master/en-us/Exceptions/1289386765.html