### PR TITLE
[TASK] Adapt the TYPO3 version badge to the used version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Latest Stable Version](https://poser.pugx.org/friendsoftypo3/blog-example/v/stable.svg)](https://extensions.typo3.org/extension/blog_example/)
-[![TYPO3 10](https://img.shields.io/badge/TYPO3-10-orange.svg?style=flat-square)](https://get.typo3.org/version/10)
+[![TYPO3 11](https://img.shields.io/badge/TYPO3-11-orange.svg?style=flat-square)](https://get.typo3.org/version/11)
 [![Total Downloads](https://poser.pugx.org/friendsoftypo3/blog-example/d/total.svg)](https://packagist.org/packages/friendsoftypo3/blog-example)
 [![Monthly Downloads](https://poser.pugx.org/friendsoftypo3/blog-example/d/monthly)](https://packagist.org/packages/friendsoftypo3/blog-example)
 


### PR DESCRIPTION
This extension now is for TYPO3 11LTS, not for 10LTS anymore,
and the badge should reflect that.