### PR TITLE
[TASK] Remove t3ver_label

### DIFF
--- a/Configuration/TCA/tx_blogexample_domain_model_blog.php
+++ b/Configuration/TCA/tx_blogexample_domain_model_blog.php
@@ -56,13 +56,6 @@ return [
                 'default' => '',
             ],
         ],
-        't3ver_label' => [
-            'displayCond' => 'FIELD:t3ver_label:REQ:true',
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'none',
-            ]
-        ],
         'hidden' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.enabled',


### PR DESCRIPTION
This was removed from Core with v10.0:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Breaking-87193-DeprecatedFunctionalityRemoved.html?highlight=t3ver_label