### PR TITLE
[TASK] Add a PHP version requirement to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     }
   },
   "require": {
+    "php": "^7.4 || ^8.0",
     "typo3/cms-core": "^11.5",
     "typo3/cms-extbase": "^11.5",
     "typo3/cms-fluid": "^11.5"


### PR DESCRIPTION
This allows IDEs like PhpStorm to automatically set the correct
language level.