### PR TITLE
[BUGFIX] Add `typo3fluid/fluid` as an explicit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
   "require": {
     "typo3/cms-core": "^11.5",
     "typo3/cms-extbase": "^11.5",
-    "typo3/cms-fluid": "^11.5"
+    "typo3/cms-fluid": "^11.5",
+    "typo3fluid/fluid": "^2.7.2"
   }
 }


### PR DESCRIPTION
This extension uses classes from the `typo3fluid/fluid` and hence should
have it as an explicit requirement. (Relying on transitive dependencies
is bad practices as the dependencies' dependencies are allowed to change
without notice.)