### PR TITLE
[TASK] Migrate backport to shared reusable workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,19 +1,21 @@
 name: Backport
+
 on:
   pull_request_target:
     types:
       - closed
       - labeled
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
 jobs:
   backport:
-    runs-on: ubuntu-latest
-    name: Backport
-    permissions:
-      contents: write        # needed to push the backport branch
-      pull-requests: write   # needed to open the PR
-    steps:
-      - name: Backport
-        uses: m-kuhn/backport@30b6e83906cc97bad3a02867181d6236becf68f9
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-backport.yml@main
+    with:
+      label_pattern: "^backport (.+)$"
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

blog_example was the **last** TYPO3-Documentation repo still referencing the broken [`m-kuhn/backport@30b6e83`](https://github.com/m-kuhn/backport/commit/30b6e83) action (missing `dist/index.js` — the original bug that started the shared-workflows initiative). This replaces it with the org shared [`reusable-backport.yml`](https://github.com/TYPO3-Documentation/.github/blob/main/.github/workflows/reusable-backport.yml), matching the 9 already-migrated repos.

## Change

```diff
-    steps:
-      - name: Backport
-        uses: m-kuhn/backport@30b6e83...   # BROKEN — missing dist/index.js
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-backport.yml@main
+    with:
+      label_pattern: "^backport (.+)$"
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
```

## ⚠️ One thing a maintainer must confirm

The shared workflow generates a GitHub App token from `APP_ID` / `APP_PRIVATE_KEY` (so backport PRs trigger their own CI) — it does **not** fall back to `GITHUB_TOKEN`. The 9 sibling repos rely on these secrets being available org-wide, but I could not verify that blog_example has access (secret listing is admin-gated). **Please confirm blog_example is in the scope of the org `APP_ID` / `APP_PRIVATE_KEY` secrets before relying on the first backport.** This is not a regression risk: the current action is already broken, so the migration is neutral-or-better either way.

## Reference style

Uses `@main`, matching the open migration PRs (TYPO3-Documentation/TYPO3CMS-Tutorial-Editors#258, TYPO3-Documentation/render-guides#1196) and the recommendation in ADR-003 (TYPO3-Documentation/.github#6). If maintainers decide on SHA-pinning there, this can be pinned to match.

## Related

- Tracked in TYPO3-Documentation/.github#5 (this was the last unchecked backport migration).

## Test plan

- [x] `actionlint` clean
- [ ] Maintainer confirms `APP_ID`/`APP_PRIVATE_KEY` reach blog_example
- [ ] First labeled+merged PR produces a backport PR (end-to-end)
